### PR TITLE
Vendorfield should be failing if NOT string

### DIFF
--- a/src/components/ark-qrcode/ark-qrcode.tsx
+++ b/src/components/ark-qrcode/ark-qrcode.tsx
@@ -33,7 +33,7 @@ export class ArkQRCode {
 
   @Watch('vendorField')
   validateVendorField () {
-    if (typeof this.vendorField == 'string' && decodeURIComponent(this.vendorField) == this.vendorField) throw new Error('vendorField: must be a UTF-8 encoded string');
+    if (typeof this.vendorField !== 'string' && decodeURIComponent(this.vendorField) === this.vendorField) throw new Error('vendorField: must be a UTF-8 encoded string');
     if (decodeURIComponent(this.vendorField).length > 64) throw new Error('vendorField: enter no more than 64 characters');
   }
 

--- a/src/components/ark-qrcode/ark-qrcode.tsx
+++ b/src/components/ark-qrcode/ark-qrcode.tsx
@@ -33,7 +33,7 @@ export class ArkQRCode {
 
   @Watch('vendorField')
   validateVendorField () {
-    if (typeof this.vendorField !== 'string' && decodeURIComponent(this.vendorField) === this.vendorField) throw new Error('vendorField: must be a UTF-8 encoded string');
+    if (typeof this.vendorField !== 'string' || decodeURIComponent(this.vendorField) !== this.vendorField) throw new Error('vendorField: must be a UTF-8 encoded string');
     if (decodeURIComponent(this.vendorField).length > 64) throw new Error('vendorField: enter no more than 64 characters');
   }
 


### PR DESCRIPTION
This was causing me grief, but I believe this may be the cause. I kept getting this error thrown: "vendorField: must be a UTF-8 encoded string" even though my vendorField was valid, even a simple string like "blah"

I think it's supposed to be checking if it's type !== to a 'string'